### PR TITLE
Skip runtime_false deps

### DIFF
--- a/lib/mix/tasks/archive/build.deps.ex
+++ b/lib/mix/tasks/archive/build.deps.ex
@@ -60,6 +60,7 @@ defmodule Mix.Tasks.Archive.Build.Deps do
     ## Build delendencies archives
     Mix.Dep.load_on_environment(env: Mix.env())
     |> Enum.filter(fn %Mix.Dep{app: app} -> not Enum.member?(skip, app) end)
+    |> Enum.filter(fn %Mix.Dep{opts: opts} -> Keyword.get(opts, :runtime, true) end)
     |> Enum.map(fn %Mix.Dep{app: app, status: status} ->
       version =
         case status do


### PR DESCRIPTION
Specifically will be used to not distribute nimble_parsec after merging
https://github.com/elixir-lsp/elixir-ls/pull/609